### PR TITLE
Remove CFBundleExecutable key from AffirmSDK.bundle/Info.plist

### DIFF
--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
When archiving with a Release scheme, the build succeeded. However, when uploading it to iTunes Connect, we received the following error:

>[Transporter Error Output]: ERROR ITMS-90535: "Unexpected CFBundleExecutable Key. The bundle at 'Payload/StockX.app/Frameworks/AffirmSDK.framework/AffirmSDK.bundle' does not contain a bundle executable. If this bundle intentionally does not contain an executable, consider removing the CFBundleExecutable key from its Info.plist and using a CFBundlePackageType of BNDL. If this bundle is part of a third-party framework, consider contacting the developer of the framework for an update to address this issue."

I did some Googling and found this SO post that outlines the issue: [https://stackoverflow.com/questions/32096130](https://stackoverflow.com/questions/32096130).

It looks like we can just nix the `CFBundleExecutable` key and call it a day. I believe this is the same issue reported in https://github.com/Affirm/affirm-ios-sdk/issues/5 (unfortunately, the issue was abandoned).

Let me know if you have any questions or concerns!
