### PR TITLE
Fix crash when tapping on external links during checkout

### DIFF
--- a/AffirmSDK/AffirmCheckoutViewController.m
+++ b/AffirmSDK/AffirmCheckoutViewController.m
@@ -150,8 +150,10 @@
             [AffirmLogger logEvent:@"External link selected from checkout" info:@{@"checkout_ari": self.checkoutARI, @"selected_link": URL.absoluteString}];
             decisionHandler(WKNavigationActionPolicyCancel);
         }
+        else {
+            decisionHandler(WKNavigationActionPolicyAllow);
+        }
     }];
-    decisionHandler(WKNavigationActionPolicyAllow);
 }
 
 - (void)webView:(WKWebView *)webView checkIfURL:(NSString *)URLString isPopupWithCompletion:(void(^)(BOOL isPopup))completion {


### PR DESCRIPTION
This PR fixes a nasty crash when a user is on the final checkout screen and tries tapping on one of the fine print links (such as Credit Score Disclosure). This is very problematic not only because the app crashes at the very final step of the checkout flow which could discourage customers from doing it all over a second time and costing us a sale, but it also gives the impression that we're hiding the disclosures from customers.

Here is the reason for the crash:

```
*** Terminating app due to uncaught exception
'NSInternalInconsistencyException', reason: 'Completion handler passed
to -[AffirmCheckoutViewController
webView:decidePolicyForNavigationAction:decisionHandler:] was called
more than once'
***
```

This is a very simple fix. All we had to do was ensure we only call the decisionHandler ***once*** instead of twice.

## GIFs
### Before

A recap of the issue before the fixes in this PR were applied.

![before](https://user-images.githubusercontent.com/2835199/33496555-a9c87d1c-d698-11e7-91d6-082710a3616c.gif)

### After

After the fixes in this PR are applied, the external links can be tapped again without crashing the app.

![after](https://user-images.githubusercontent.com/2835199/33496559-ac12ecec-d698-11e7-8965-132c6f35e1f5.gif)

After the fixes in this PR are applied, the entire checkout flow still works flawlessly.

![flow still works](https://user-images.githubusercontent.com/2835199/33496562-b0cf6184-d698-11e7-85bc-fa403c38dc79.gif)
