### PR TITLE
Convert all null JSON values from the API to nil to prevent crashes

### DIFF
--- a/AffirmSDK.xcodeproj/project.pbxproj
+++ b/AffirmSDK.xcodeproj/project.pbxproj
@@ -71,6 +71,13 @@
 		AFAC22C91B3B720B00BFBB18 /* AffirmTestData.m in Sources */ = {isa = PBXBuildFile; fileRef = AFAC22C81B3B720B00BFBB18 /* AffirmTestData.m */; };
 		AFAC22CB1B3B7B4F00BFBB18 /* AffirmCheckoutViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AFAC22CA1B3B7B4F00BFBB18 /* AffirmCheckoutViewControllerTests.m */; };
 		AFAC22D11B41EC6D00BFBB18 /* AffirmConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AFAC22D01B41EC6D00BFBB18 /* AffirmConfigurationTests.m */; };
+		F68360031FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.h in Headers */ = {isa = PBXBuildFile; fileRef = F68360011FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.h */; };
+		F68360041FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.m in Sources */ = {isa = PBXBuildFile; fileRef = F68360021FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.m */; };
+		F68360061FEAC88700C6FC0C /* NSJSONSerialization+RemovingNullsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F68360051FEAC88700C6FC0C /* NSJSONSerialization+RemovingNullsTests.m */; };
+		F68360071FEAC8DE00C6FC0C /* NSJSONSerialization+RemovingNulls.m in Sources */ = {isa = PBXBuildFile; fileRef = F68360021FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.m */; };
+		F683600A1FEAE28A00C6FC0C /* NSString+AffirmUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F68360081FEAE28A00C6FC0C /* NSString+AffirmUtils.h */; };
+		F683600B1FEAE28A00C6FC0C /* NSString+AffirmUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F68360091FEAE28A00C6FC0C /* NSString+AffirmUtils.m */; };
+		F683600C1FEAE29500C6FC0C /* NSString+AffirmUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F68360091FEAE28A00C6FC0C /* NSString+AffirmUtils.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -116,6 +123,11 @@
 		AFAC22C81B3B720B00BFBB18 /* AffirmTestData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AffirmTestData.m; sourceTree = "<group>"; };
 		AFAC22CA1B3B7B4F00BFBB18 /* AffirmCheckoutViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AffirmCheckoutViewControllerTests.m; sourceTree = "<group>"; };
 		AFAC22D01B41EC6D00BFBB18 /* AffirmConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AffirmConfigurationTests.m; sourceTree = "<group>"; };
+		F68360011FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSJSONSerialization+RemovingNulls.h"; sourceTree = "<group>"; };
+		F68360021FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSJSONSerialization+RemovingNulls.m"; sourceTree = "<group>"; };
+		F68360051FEAC88700C6FC0C /* NSJSONSerialization+RemovingNullsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSJSONSerialization+RemovingNullsTests.m"; sourceTree = "<group>"; };
+		F68360081FEAE28A00C6FC0C /* NSString+AffirmUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+AffirmUtils.h"; sourceTree = "<group>"; };
+		F68360091FEAE28A00C6FC0C /* NSString+AffirmUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+AffirmUtils.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,6 +183,10 @@
 				4E078C071F168A5400395ECE /* AffirmSDK.h */,
 				4E078B121F1044DA00395ECE /* AffirmUtils.h */,
 				4E078B131F1044DA00395ECE /* AffirmUtils.m */,
+				F68360011FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.h */,
+				F68360021FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.m */,
+				F68360081FEAE28A00C6FC0C /* NSString+AffirmUtils.h */,
+				F68360091FEAE28A00C6FC0C /* NSString+AffirmUtils.m */,
 			);
 			path = AffirmSDK;
 			sourceTree = "<group>";
@@ -203,6 +219,7 @@
 				AFAC22CA1B3B7B4F00BFBB18 /* AffirmCheckoutViewControllerTests.m */,
 				AFAC22D01B41EC6D00BFBB18 /* AffirmConfigurationTests.m */,
 				AFA815CD1B83FFB800A06A34 /* AffirmUtilsTests.m */,
+				F68360051FEAC88700C6FC0C /* NSJSONSerialization+RemovingNullsTests.m */,
 				AF9426001B26610000D45762 /* Supporting Files */,
 			);
 			path = AffirmSDKTests;
@@ -231,6 +248,7 @@
 				4E078BA81F14334600395ECE /* AffirmConfiguration.h in Headers */,
 				4E704B7E1F16DF6B000FDFBB /* AffirmCheckoutViewController+Protected.h in Headers */,
 				4E078BA51F14334600395ECE /* AffirmCheckoutData.h in Headers */,
+				F683600A1FEAE28A00C6FC0C /* NSString+AffirmUtils.h in Headers */,
 				4E078BA91F14334600395ECE /* AffirmErrorModal.h in Headers */,
 				4E704B801F16DF7E000FDFBB /* AffirmConfiguration+Protected.h in Headers */,
 				4E078BA31F14334600395ECE /* AffirmAsLowAsData.h in Headers */,
@@ -241,6 +259,7 @@
 				4E078BAB1F14334600395ECE /* AffirmLogger.h in Headers */,
 				4E078BAC1F14334600395ECE /* AffirmPopupViewController.h in Headers */,
 				4E078BA41F14334600395ECE /* AffirmBaseModalViewController.h in Headers */,
+				F68360031FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.h in Headers */,
 				4E078BA61F14334600395ECE /* AffirmCheckoutDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -365,7 +384,9 @@
 			files = (
 				4E078BFB1F1689FC00395ECE /* AffirmActivityIndicator.m in Sources */,
 				4E078BFC1F1689FC00395ECE /* AffirmAsLowAsButton.m in Sources */,
+				F683600B1FEAE28A00C6FC0C /* NSString+AffirmUtils.m in Sources */,
 				4E078BFD1F1689FC00395ECE /* AffirmAsLowAsData.m in Sources */,
+				F68360041FEAC5A700C6FC0C /* NSJSONSerialization+RemovingNulls.m in Sources */,
 				4E078BFE1F1689FC00395ECE /* AffirmBaseModalViewController.m in Sources */,
 				4E078BFF1F1689FC00395ECE /* AffirmCheckoutData.m in Sources */,
 				4E078C001F1689FC00395ECE /* AffirmCheckoutViewController.m in Sources */,
@@ -384,11 +405,14 @@
 			files = (
 				AFAC22D11B41EC6D00BFBB18 /* AffirmConfigurationTests.m in Sources */,
 				AFAC22C61B3B5A7000BFBB18 /* AffirmCheckoutDataTests.m in Sources */,
+				F68360061FEAC88700C6FC0C /* NSJSONSerialization+RemovingNullsTests.m in Sources */,
+				F68360071FEAC8DE00C6FC0C /* NSJSONSerialization+RemovingNulls.m in Sources */,
 				4E078B3A1F1044DA00395ECE /* AffirmPromoModalViewController.m in Sources */,
 				AFAC22C91B3B720B00BFBB18 /* AffirmTestData.m in Sources */,
 				4E078B291F1044DA00395ECE /* AffirmCheckoutViewController.m in Sources */,
 				4E078B3E1F1044DA00395ECE /* AffirmUtils.m in Sources */,
 				4E078B301F1044DA00395ECE /* AffirmErrorModal.m in Sources */,
+				F683600C1FEAE29500C6FC0C /* NSString+AffirmUtils.m in Sources */,
 				4E078B161F1044DA00395ECE /* AffirmActivityIndicator.m in Sources */,
 				AFA815CE1B83FFB800A06A34 /* AffirmUtilsTests.m in Sources */,
 				4EF6085C1F33A002004A0EFB /* AffirmAsLowAsTests.m in Sources */,

--- a/AffirmSDK/AffirmUtils.m
+++ b/AffirmSDK/AffirmUtils.m
@@ -7,7 +7,7 @@
 //
 
 #import "AffirmUtils.h"
-
+#import "NSJSONSerialization+RemovingNulls.h"
 
 @implementation AffirmNumberUtils
 
@@ -83,7 +83,7 @@
 + (void) performNetworkRequest:(NSURLRequest *)request withCompletion:(AffirmNetworkCompletion)completion {
     NSURLSession *session = [NSURLSession sharedSession];
     NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request completionHandler:^(NSData *_data, NSURLResponse *_response, NSError *error) {
-        NSDictionary *data = _data ? [NSJSONSerialization JSONObjectWithData:_data options:NSJSONReadingMutableContainers error:nil] : nil;
+        NSDictionary *data = _data ? [NSJSONSerialization AF_JSONObjectWithData:_data options:NSJSONReadingMutableContainers error:nil removingNulls:YES ignoreArrays:NO] : nil;
         NSHTTPURLResponse *response = (NSHTTPURLResponse *)_response;
         completion(data, response, error);
     }];

--- a/AffirmSDK/NSJSONSerialization+RemovingNulls.h
+++ b/AffirmSDK/NSJSONSerialization+RemovingNulls.h
@@ -1,0 +1,34 @@
+//
+//  NSJSONSerialization+RemovingNulls.h
+//  AffirmSDK
+//
+//  Created by Laurent Shala on 12/20/17.
+//  Copyright © 2017 Affirm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSJSONSerialization (RemovingNulls)
+
+/** Converts the data to a JSON object, with the ability to all remove NSNull values. */
++ (id)AF_JSONObjectWithData:(NSData *)data
+                    options:(NSJSONReadingOptions)opt
+                      error:(NSError * __autoreleasing *)error
+              removingNulls:(BOOL)removingNulls
+               ignoreArrays:(BOOL)ignoreArrays;
+
+@end
+
+@interface NSMutableDictionary (RemovingNulls)
+
+- (void)AF_recursivelyRemoveNulls;
+- (void)AF_recursivelyRemoveNullsIgnoringArrays:(BOOL)ignoringArrays;
+
+@end
+
+@interface NSMutableArray (RemovingNulls)
+
+- (void)AF_recursivelyRemoveNulls;
+- (void)AF_recursivelyRemoveNullsIgnoringArrays:(BOOL)ignoringArrays;
+
+@end

--- a/AffirmSDK/NSJSONSerialization+RemovingNulls.m
+++ b/AffirmSDK/NSJSONSerialization+RemovingNulls.m
@@ -1,0 +1,120 @@
+//
+//  NSJSONSerialization+RemovingNulls.m
+//  AffirmSDK
+//
+//  Created by Laurent Shala on 12/20/17.
+//  Copyright © 2017 Affirm. All rights reserved.
+//
+
+#import "NSJSONSerialization+RemovingNulls.h"
+
+@implementation NSJSONSerialization (RemovingNulls)
+
++ (id)AF_JSONObjectWithData:(NSData *)data
+                    options:(NSJSONReadingOptions)opt
+                      error:(NSError * __autoreleasing *)error
+              removingNulls:(BOOL)removingNulls
+               ignoreArrays:(BOOL)ignoreArrays {
+    // Mutable containers are required to remove nulls.
+    if (removingNulls) {
+        // Force add NSJSONReadingMutableContainers since the null removal depends on it.
+        opt = opt | NSJSONReadingMutableContainers;
+    }
+    
+    id jsonObject = [self JSONObjectWithData:data options:opt error:error];
+    
+    if ((error && *error) || !removingNulls) {
+        return jsonObject;
+    }
+    
+    if (![jsonObject isKindOfClass:[NSArray class]] && ![jsonObject isKindOfClass:[NSDictionary class]]) {
+        return jsonObject;
+    }
+    
+    [jsonObject AF_recursivelyRemoveNullsIgnoringArrays:ignoreArrays];
+    
+    return jsonObject;
+}
+
+@end
+
+@implementation NSMutableDictionary (RemovingNulls)
+
+- (void)AF_recursivelyRemoveNulls {
+    [self AF_recursivelyRemoveNullsIgnoringArrays:NO];
+}
+
+- (void)AF_recursivelyRemoveNullsIgnoringArrays:(BOOL)ignoringArrays {
+    // First, filter out directly stored nulls
+    NSMutableArray *nullKeys = [NSMutableArray array];
+    NSMutableArray *arrayKeys = [NSMutableArray array];
+    NSMutableArray *dictionaryKeys = [NSMutableArray array];
+    
+    [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        if (obj == [NSNull null]) {
+            [nullKeys addObject:key];
+        }
+        else if ([obj isKindOfClass:[NSDictionary  class]]) {
+            [dictionaryKeys addObject:key];
+        }
+        else if ([obj isKindOfClass:[NSArray class]]) {
+            [arrayKeys addObject:key];
+        }
+    }];
+    
+    // Remove all the nulls
+    [self removeObjectsForKeys:nullKeys];
+    
+    // Recursively remove nulls from arrays
+    for (id arrayKey in arrayKeys) {
+        NSMutableArray *array = self[arrayKey];
+        [array AF_recursivelyRemoveNullsIgnoringArrays:ignoringArrays];
+    }
+    
+    // Cascade down the dictionaries
+    for (id dictionaryKey in dictionaryKeys) {
+        NSMutableDictionary *dictionary = self[dictionaryKey];
+        [dictionary AF_recursivelyRemoveNullsIgnoringArrays:ignoringArrays];
+    }
+}
+
+@end
+
+@implementation NSMutableArray (RemovingNulls)
+
+- (void)AF_recursivelyRemoveNulls {
+    [self AF_recursivelyRemoveNullsIgnoringArrays:NO];
+}
+
+- (void)AF_recursivelyRemoveNullsIgnoringArrays:(BOOL)ignoringArrays {
+    // First, filter out directly stored nulls if required
+    if (!ignoringArrays) {
+        [self filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+            return evaluatedObject != [NSNull null];
+        }]];
+    }
+    
+    NSMutableIndexSet *arrayIndexes = [NSMutableIndexSet indexSet];
+    NSMutableIndexSet *dictionaryIndexes = [NSMutableIndexSet indexSet];
+    
+    [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        if ([obj isKindOfClass:[NSDictionary  class]]) {
+            [dictionaryIndexes addIndex:idx];
+        }
+        else if ([obj isKindOfClass:[NSArray class]]) {
+            [arrayIndexes addIndex:idx];
+        }
+    }];
+    
+    // Recursively remove nulls from arrays
+    for (NSMutableArray *containedArray in [self objectsAtIndexes:arrayIndexes]) {
+        [containedArray AF_recursivelyRemoveNullsIgnoringArrays:ignoringArrays];
+    }
+    
+    // Cascade down the dictionaries
+    for (NSMutableDictionary *containedDictionary in [self objectsAtIndexes:dictionaryIndexes]) {
+        [containedDictionary AF_recursivelyRemoveNullsIgnoringArrays:ignoringArrays];
+    }
+}
+
+@end

--- a/AffirmSDK/NSString+AffirmUtils.h
+++ b/AffirmSDK/NSString+AffirmUtils.h
@@ -1,0 +1,16 @@
+//
+//  NSString+AffirmUtils.h
+//  AffirmSDK
+//
+//  Created by Laurent Shala on 12/20/17.
+//  Copyright © 2017 Affirm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (AffirmUtils)
+
+/** Returns nil when self is @"", otherwise returns self. */
+- (instancetype)AF_nonEmptyValue;
+
+@end

--- a/AffirmSDK/NSString+AffirmUtils.m
+++ b/AffirmSDK/NSString+AffirmUtils.m
@@ -1,0 +1,17 @@
+//
+//  NSString+AffirmUtils.m
+//  AffirmSDK
+//
+//  Created by Laurent Shala on 12/20/17.
+//  Copyright © 2017 Affirm. All rights reserved.
+//
+
+#import "NSString+AffirmUtils.h"
+
+@implementation NSString (AffirmUtils)
+
+- (instancetype)AF_nonEmptyValue {
+    return self.length > 0 ? self : nil;
+}
+
+@end

--- a/AffirmSDKTests/NSJSONSerialization+RemovingNullsTests.m
+++ b/AffirmSDKTests/NSJSONSerialization+RemovingNullsTests.m
@@ -1,0 +1,31 @@
+//
+//  NSJSONSerialization+RemovingNullsTests.m
+//  AffirmSDKTests
+//
+//  Created by Laurent Shala on 12/20/17.
+//  Copyright © 2017 Affirm. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSJSONSerialization+RemovingNulls.h"
+
+@interface NSJSONSerializationPlusRemovingNullsTests : XCTestCase
+@end
+
+@implementation NSJSONSerializationPlusRemovingNullsTests
+
+- (void)testNullsWereRemoved {
+    NSData *data = [NSJSONSerialization dataWithJSONObject:@{@"not null": @"some value",
+                                                             @"null": [NSNull null]}
+                                                   options:NSJSONWritingPrettyPrinted
+                                                     error:NULL];
+    
+    NSDictionary *dict = [NSJSONSerialization AF_JSONObjectWithData:data options:0 error:NULL removingNulls:YES ignoreArrays:NO];
+    
+    XCTAssertEqualObjects(dict[@"not null"], @"some value");
+    
+    XCTAssertNotEqual(dict[@"null"], [NSNull null]);
+    XCTAssertNil(dict[@"null"]);
+}
+
+@end


### PR DESCRIPTION
This prevents an array of crashes due to calling methods on NSNull which is not permissible with Obj-C.

One of the main crashes we were seeing was the `loanTerm` `pricingTemplate` coming back as null from the API. Trying to use NSString methods on null caused many crashes. By using nil instead, Obj-C will not crash.

>Fatal Exception: NSInvalidArgumentException
>-[NSNull stringByReplacingOccurrencesOfString:withString:]: unrecognized selector sent to instance 0x1b3d43650

In addition we check against nil and empty string before building the pricing string, otherwise, we return the default pricing string. That way we only build the pricing string from the template if all the components are available.