### PR TITLE
Fixed a bug that was causing the loading indicator in AffirmBaseModalViewController to not be centered.

### DIFF
--- a/AffirmSDK/AffirmBaseModalViewController.m
+++ b/AffirmSDK/AffirmBaseModalViewController.m
@@ -42,6 +42,7 @@
     [self.view addConstraints:@[top, bottom, left, right]];
     
     self.loadingIndicator.center = self.view.center;
+    self.loadingIndicator.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     self.loadingIndicator.indicatorColor = [UIColor colorWithRed:16/255.0 green:160/255.0 blue:234/255.0 alpha: 1.0];
     self.loadingIndicator.indicatorPathColor = [UIColor colorWithRed:246/255.0 green:248/255.0 blue:252/255.0 alpha:1.0];
     self.loadingIndicator.indicatorLineWidth = 1.5;


### PR DESCRIPTION
This was an issue on iPad when using modal presentations style form sheet.

Before
<img width="731" alt="screen shot 2018-10-19 at 11 08 31 am" src="https://user-images.githubusercontent.com/859190/47236125-08220a00-d390-11e8-8f56-1298d9406791.png">

After
<img width="731" alt="screen shot 2018-10-19 at 11 08 47 am" src="https://user-images.githubusercontent.com/859190/47236130-0c4e2780-d390-11e8-881a-e4ff5e2faad8.png">
