### PR TITLE
Use non-cdn endpoint

### DIFF
--- a/AffirmSDK/AffirmConfiguration+Protected.h
+++ b/AffirmSDK/AffirmConfiguration+Protected.h
@@ -17,8 +17,8 @@ static NSString *AFFIRM_CHECKOUT_CANCELLATION_URL = @"affirm://checkout/cancelle
 static NSString *AFFIRM_PRODUCTION_DOMAIN = @"api.affirm.com";
 static NSString *AFFIRM_SANDBOX_DOMAIN = @"sandbox.affirm.com";
 
-static NSString *AFFIRM_ALA_PRODUCTION_DOMAIN = @"cdn1.affirm.com";
-static NSString *AFFIRM_ALA_SANDBOX_DOMAIN = @"cdn1-sandbox.affirm.com";
+static NSString *AFFIRM_ALA_PRODUCTION_DOMAIN = @"affirm.com";
+static NSString *AFFIRM_ALA_SANDBOX_DOMAIN = @"sandbox.affirm.com";
 
 @interface AffirmConfiguration () <NSCopying>
 


### PR DESCRIPTION
For some reason, the CDN endpoints for ALAs aren't passing query parameters through to Flask. This is causing the SDK tests to fail.

This diff modifies the ALA endpoints to use the non-CDN routes. It shouldn't cause any production issues. The tests now pass as well.