### PR TITLE
Update promo template to listen for prequal:close

### DIFF
--- a/AffirmSDK/AffirmSDK.bundle/promo_modal_template.html
+++ b/AffirmSDK/AffirmSDK.bundle/promo_modal_template.html
@@ -68,6 +68,7 @@
             var onCloseProductModal = function() {
                 window.location.href = "%@"
             }
+            affirm.events.on('prequal:close', onCloseProductModal);
             affirm.setAffirmConfig(elem, {onCloseModal: onCloseProductModal});
         });
         // END AFFIRM.JS EMBED CODE


### PR DESCRIPTION
The new promo modal now uses AFJS's `PrequalWidget`, which emits the `prequal:close` event when it closes. We should listen for this event here (as is now done in the [Android SDK](https://github.com/Affirm/affirm-android-sdk/pull/14/files)) as well as the old event, which is needed for Affirm Go promos.