### PR TITLE
make promo ID publicly accessible

### DIFF
--- a/AffirmSDK/AffirmAsLowAsButton.h
+++ b/AffirmSDK/AffirmAsLowAsButton.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AffirmAsLowAsButton : UIButton
 
 @property (nonatomic, weak) id presentingViewController;
+@property (nonatomic, strong) NSString *promoID;
 
 /// Convenience constructor that creates an as low as button
 /// @param promoID Promo ID to use when getting terms (provided by Affirm)

--- a/AffirmSDK/AffirmAsLowAsButton.m
+++ b/AffirmSDK/AffirmAsLowAsButton.m
@@ -15,7 +15,6 @@
 @interface AffirmAsLowAsButton()
 
 @property (nonatomic, strong) NSDecimalNumber *amount;
-@property (nonatomic, strong) NSString *promoID;
 @property (nonatomic, assign) BOOL showPrequal;
 @end
 


### PR DESCRIPTION
This diff makes the promo ID publicly accessible for use by the demo app in #32.